### PR TITLE
Defer immediate completion trigger to next main-loop event

### DIFF
--- a/lua/lsp_compl.lua
+++ b/lua/lsp_compl.lua
@@ -256,7 +256,7 @@ function M._InsertCharPre(client_id)
 
       local debounce_ms = next_debounce(opts.subsequent_debounce)
       if debounce_ms == 0 then
-        M.trigger_completion()
+        vim.schedule(M.trigger_completion)
       else
         timer = vim.loop.new_timer()
         timer:start(debounce_ms, 0, vim.schedule_wrap(M.trigger_completion))


### PR DESCRIPTION
`InsertCharPre` is too early - where the char being inserted isn't
available yet.
