### PR TITLE
Call `complete` also if there are no candidates

### DIFF
--- a/lua/lsp_compl.lua
+++ b/lua/lsp_compl.lua
@@ -330,11 +330,7 @@ function M.trigger_completion()
         vim.list_extend(all_matches, matches)
       end
     end
-    if next(all_matches) then
-      vim.fn.complete(startbyte or col, all_matches)
-    else
-      print('No completion result')
-    end
+    vim.fn.complete(startbyte or col, all_matches)
   end)
   table.insert(completion_ctx.pending_requests, cancel_req)
 end

--- a/lua/lsp_compl.lua
+++ b/lua/lsp_compl.lua
@@ -594,9 +594,9 @@ function M.capabilities()
         completionItem = {
           snippetSupport = has_snippet_support,
           labelDetailsSupport = true,
-        },
-        resolveSupport = {
-          properties = {'edit', 'documentation', 'detail'}
+          resolveSupport = {
+            properties = {'edit', 'documentation', 'detail'}
+          },
         }
       }
     }


### PR DESCRIPTION
If using fuzzy match and there are no subsequent matches, the popup menu
stays open if `complete` isn't called again and it appears as if
matching doesn't work.
