### PR TITLE
Improve CompletionItem conversion handling for vscode-json-languageserver

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+    "Lua.workspace.checkThirdParty": false
+}

--- a/tests/lsp_compl_spec.lua
+++ b/tests/lsp_compl_spec.lua
@@ -181,7 +181,7 @@ describe('item conversion', function()
       insertText = "query_definition",
       label = "query_definition(pattern)",
     }
-    local item = compl._convert_item(lsp_item, false)
+    local item = compl._convert_item(lsp_item, false, 0)
     assert.are.same('query_definition', item.word)
   end)
   it('uses label as word if insertText available but longer than label and format is snippet', function()
@@ -190,7 +190,7 @@ describe('item conversion', function()
       insertText = "testSuites ${1:Env}",
       label = "testSuites",
     }
-    local item = compl._convert_item(lsp_item, false)
+    local item = compl._convert_item(lsp_item, false, 0)
     assert.are.same('testSuites', item.word)
   end)
 
@@ -202,7 +202,20 @@ describe('item conversion', function()
       },
       label = "insert",
     }
-    local item = compl._convert_item(lsp_item, false)
+    local item = compl._convert_item(lsp_item, false, 0)
     assert.are.same('insert', item.word)
+  end)
+
+  it("Uses text if label matches prefix with offset applied", function()
+    -- vscode-json-languageserver includes quotes in the newText, but not in the label
+    local lsp_item = {
+      insertTextFormat = 2,
+      textEdit = {
+        newText = '"arrow_spacing"',
+      },
+      label = "arrow_spacing"
+    }
+    local item = compl._convert_item(lsp_item, false, 1)
+    assert.are.same('"arrow_spacing"', item.word, 1)
   end)
 end)

--- a/tests/lsp_compl_spec.lua
+++ b/tests/lsp_compl_spec.lua
@@ -174,3 +174,35 @@ describe('lsp_compl', function()
     assert.are.same({ line = 1, character = 1}, candidate.user_data.textEdit.range.start)
   end)
 end)
+
+describe('item conversion', function()
+  it('uses insertText as word if available and shorter than label', function()
+    local lsp_item = {
+      insertText = "query_definition",
+      label = "query_definition(pattern)",
+    }
+    local item = compl._convert_item(lsp_item, false)
+    assert.are.same('query_definition', item.word)
+  end)
+  it('uses label as word if insertText available but longer than label and format is snippet', function()
+    local lsp_item = {
+      insertTextFormat = 2,
+      insertText = "testSuites ${1:Env}",
+      label = "testSuites",
+    }
+    local item = compl._convert_item(lsp_item, false)
+    assert.are.same('testSuites', item.word)
+  end)
+
+  it("uses label if textEdit.newText doesn't start with label", function()
+    local lsp_item = {
+      insertTextFormat = 2,
+      textEdit = {
+        newText = "table.insert(f, $0)",
+      },
+      label = "insert",
+    }
+    local item = compl._convert_item(lsp_item, false)
+    assert.are.same('insert', item.word)
+  end)
+end)


### PR DESCRIPTION
In a file like:

```
{
  "|
}
```

The column retrieved via `vim.fn.match(line_to_cursor, '\\k*$')` will be
3

The language server has a different starting point and includes the `"`
in the completion items.

```
label: arrow_spacing
textEdit: table: 0x7fde68f19388
  newText: "arrow_spacing"
  range: table: 0x7fde68f193d0
    end: table: 0x7fde68f194d0
      character: 3
      line: 2
    start: table: 0x7fde68f19418
      character: 2
      line: 2
```

This starting point divergence must be accounted for when determining if
the `label` or `newText` should be used as `word`.

If `label` would be used, typing any character would end the completion.
Candidates would stop matching because `complete()` was called with the
lower starting position _before_ the `"`.
