### PR TITLE
Check for existing client when detaching

### DIFF
--- a/lua/lsp_compl.lua
+++ b/lua/lsp_compl.lua
@@ -641,9 +641,12 @@ end
 
 
 function M.detach(client_id, bufnr)
+  local c = clients[client_id]
+  if not c then
+    return
+  end
   local group = string.format('lsp_compl_%d_%d', client_id, bufnr)
   api.nvim_del_augroup_by_name(group)
-  local c = clients[client_id]
   c.num_attached = c.num_attached - 1
   if (c.num_attached == 0) then
     clients[client_id] = nil


### PR DESCRIPTION
If detach is called when no client is attached, nvim_del_augroup_by_name
returns an error because the given augroup does not exist. And even if
that call did succeed, we would quickly hit an error when accessing `c`,
which is nil.

This case can happen when the LSP server fails to start. When that
happens, an LspDetach event is fired and if the user has an LspDetach
autocommand that calls nvim_lsp_compl.detach(), this error will occur.

The solution is simply to check that the client being detached actually
exists, and exit early if it does not.
