### PR TITLE
Use insertText as textEdit.newText if textEditText is missing

### DIFF
--- a/lua/lsp_compl.lua
+++ b/lua/lsp_compl.lua
@@ -142,7 +142,7 @@ local function apply_defaults(item, defaults)
   if defaults.editRange then
     local textEdit = item.textEdit or {}
     item.textEdit = textEdit
-    textEdit.newText = textEdit.newText or item.textEditText
+    textEdit.newText = textEdit.newText or item.textEditText or item.insertText
     if defaults.editRange.start then
       textEdit.range = textEdit.range or defaults.editRange
     elseif defaults.editRange.insert then
@@ -726,7 +726,11 @@ function M.attach(client, bufnr, opts)
     api.nvim_buf_attach(bufnr, false, {
       on_detach = function(_, b)
         triggers_by_buf[b] = nil
-      end
+      end,
+      on_reload = function(_, b)
+        M.detach(client.id, b)
+        M.attach(client, b, opts)
+      end,
     })
   end
   local signature_triggers = vim.tbl_get(client.server_capabilities, 'signatureHelpProvider', 'triggerCharacters')

--- a/tests/lsp_compl_spec.lua
+++ b/tests/lsp_compl_spec.lua
@@ -174,6 +174,34 @@ describe('lsp_compl', function()
     assert.are.same({ line = 1, character = 1}, candidate.user_data.textEdit.range.start)
   end)
 
+  it("uses insertText as textEdit.newText if there are editRange defaults but no textEditText", function()
+    local server = new_server({
+      isIncomplete = false,
+      itemDefaults = {
+        editRange = {
+          start = { line = 1, character = 1 },
+          ['end'] = { line = 1, character = 4 },
+        },
+        insertTextFormat = 2,
+        data = 'foobar',
+      },
+      items = {
+        {
+          insertText = "the-insertText",
+          label = 'hello',
+          data = 'item-property-has-priority',
+        }
+      }
+    })
+    vim.lsp.start({ name = 'server', cmd = server, on_attach = compl.attach })
+    api.nvim_buf_set_lines(buf, 0, -1, true, {'a'})
+    api.nvim_win_set_cursor(win, { 1, 1 })
+    compl.trigger_completion()
+    local candidate = capture.matches[1]
+    local item = candidate.user_data
+    assert.are.same("the-insertText", item.textEdit.newText)
+  end)
+
   it('executes commands', function()
     local items = {
       {


### PR DESCRIPTION
Defaults can have `editRange` set without a `textEdit.newText` or
`item.textEditText`

This caused an error when applying a snippet as the `newText` was
missing.
